### PR TITLE
fix role-selection page's dots panel to be equally big as login page's

### DIFF
--- a/src/app/role/page.tsx
+++ b/src/app/role/page.tsx
@@ -49,14 +49,14 @@ export default function RolePage() {
       
       {/* Panel section - visible in landscape and desktop */}
       <div className="hidden landscape:flex lg:flex w-full lg:w-1/2 h-[400px] lg:h-screen items-center justify-center p-4">
-        <div className="grid grid-cols-11 gap-2 md:gap-3 xl:gap-4 w-full max-w-[400px] aspect-[11/13] [perspective:1000px]">
+        <div className="grid grid-cols-11 gap-2 md:gap-3 lg:gap-4 w-full max-w-[550px] aspect-[11/13] [perspective:1000px]">
           {[...Array(11 * 13)].map((_, i) => {
             const isC = cSequence.includes(i);
             const isS = sSequence.includes(i);
             return (
               <div
                 key={i}
-                className={`w-3 h-3 md:w-4 md:h-4 xl:w-6 xl:h-6 rounded-full ${
+                className={`w-4 h-4 md:w-5 md:h-5 lg:w-6 lg:h-6 rounded-full ${
                   isC || isS 
                     ? "dark:animate-flipDark animate-flip"
                     : "bg-gray-200 dark:bg-gray-700"


### PR DESCRIPTION
-แก้ logo CS ของหน้า role-selection ให้มันใหญ่เท่าหน้า login เฉยๆคับ พอดีว่าก่อน Push ไม่ได้เช็ค เพิ่งมาเห็น

![image](https://github.com/user-attachments/assets/40e3416e-4e64-445a-a586-31e1bcf257b4)
![image](https://github.com/user-attachments/assets/da6b5077-351d-41f9-afb2-f46253ab2fa5)

